### PR TITLE
Feat/ethereum from json

### DIFF
--- a/src/evm/evm_transaction.rs
+++ b/src/evm/evm_transaction.rs
@@ -122,12 +122,12 @@ impl EVMTransaction {
 
         let input = v["input"].as_str().unwrap_or_default().to_string();
         let input =
-            hex::decode(&input.strip_prefix("0x").unwrap_or("")).expect("input should be hex");
+            hex::decode(input.strip_prefix("0x").unwrap_or("")).expect("input should be hex");
 
         // TODO: Implement access list
         // let access_list = v["accessList"].as_str().unwrap_or_default().to_string();
 
-        Ok(EVMTransaction {
+        Ok(Self {
             chain_id,
             nonce,
             to: Some(to_parsed),
@@ -142,19 +142,17 @@ impl EVMTransaction {
 }
 
 fn parse_u64(value: &str) -> Result<u64, std::num::ParseIntError> {
-    if let Some(hex_str) = value.strip_prefix("0x") {
-        u64::from_str_radix(hex_str, 16)
-    } else {
-        value.parse::<u64>()
-    }
+    value.strip_prefix("0x").map_or_else(
+        || value.parse::<u64>(),
+        |hex_str| u64::from_str_radix(hex_str, 16),
+    )
 }
 
 fn parse_u128(value: &str) -> Result<u128, std::num::ParseIntError> {
-    if let Some(hex_str) = value.strip_prefix("0x") {
-        u128::from_str_radix(hex_str, 16)
-    } else {
-        value.parse::<u128>()
-    }
+    value.strip_prefix("0x").map_or_else(
+        || value.parse::<u128>(),
+        |hex_str| u128::from_str_radix(hex_str, 16),
+    )
 }
 
 #[cfg(test)]

--- a/src/evm/evm_transaction.rs
+++ b/src/evm/evm_transaction.rs
@@ -360,8 +360,6 @@ mod tests {
 
         let evm_tx1 = EVMTransaction::from_json(tx1).unwrap();
 
-        println!("evm_tx1: {:?}", evm_tx1);
-
         assert_eq!(evm_tx1.chain_id, 11155111);
         assert_eq!(evm_tx1.nonce, 1);
         assert_eq!(
@@ -390,8 +388,6 @@ mod tests {
         }"#;
 
         let evm_tx2 = EVMTransaction::from_json(tx2).unwrap();
-
-        println!("evm_tx2: {:?}", evm_tx2);
 
         assert_eq!(evm_tx2.chain_id, 11155111);
         assert_eq!(evm_tx2.nonce, 1);


### PR DESCRIPTION
**What changed? Why?**

- added from json implementation to enable implementers serialise raw strings to the EVMTransaction struct.
 
**Notes to reviewers**

- The PR doesn't include the serialisation of the `access-list` field. This will be completed when the full serde serialisation is applied to the EVM transaction.
 
**How has it been tested?**

The PR includes